### PR TITLE
Now works for the TTGO-lora32-v1.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -32,6 +32,6 @@ board_build.partitions = huge_app.csv
 [env:ttgo-t-beam]
 board = ttgo-t-beam
 
-;[env:ttgo-lora32-v1]
-;board = ttgo-lora32-v1
+[env:ttgo-lora32-v1]
+board = ttgo-lora32-v1
 

--- a/src/config.h
+++ b/src/config.h
@@ -1,5 +1,8 @@
 #pragma once
 
+//If the device has a GPS module
+// #define GPS_ENABLED
+
 //Using LILYGO TTGO T-BEAM v1.1 
 #define BOARD_LED   4
 #define LED_ON      LOW

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,6 +61,7 @@ void initLoRaChat() {
 
 #pragma region GPS
 
+#ifdef GPS_ENABLED
 #define UPDATE_GPS_DELAY 10000 //ms
 
 GPSService& gpsService = GPSService::getInstance();
@@ -69,6 +70,7 @@ void initGPS() {
     //Initialize GPS
     gpsService.initGPS();
 }
+#endif
 
 #pragma endregion
 
@@ -93,8 +95,10 @@ void initManager() {
     manager.addMessageService(&bluetoothService);
     Log.verboseln("Bluetooth service added to manager");
 
+#ifdef GPS_ENABLED
     manager.addMessageService(&gpsService);
     Log.verboseln("GPS service added to manager");
+#endif
 
     manager.addMessageService(&loraMeshService);
     Log.verboseln("LoRaMesher service added to manager");
@@ -123,9 +127,9 @@ void display_Task(void* pvParameters) {
 
     uint32_t lastLineTwoUpdate = 0;
     uint32_t lastLineThreeUpdate = 0;
-
+#ifdef GPS_ENABLED
     uint32_t lastGPSUpdate = 0;
-
+#endif
     while (true) {
         //Update line two every DISPLAY_LINE_TWO_DELAY ms
         if (millis() - lastLineTwoUpdate > DISPLAY_LINE_TWO_DELAY) {
@@ -134,6 +138,7 @@ void display_Task(void* pvParameters) {
             Screen.changeLineTwo(lineTwo);
         }
 
+#ifdef GPS_ENABLED
         //Update line three every DISPLAY_LINE_THREE_DELAY ms
         if (millis() - lastLineThreeUpdate > DISPLAY_LINE_THREE_DELAY) {
             lastLineThreeUpdate = millis();
@@ -146,7 +151,7 @@ void display_Task(void* pvParameters) {
             lastGPSUpdate = millis();
             gpsService.notifyUpdate();
         }
-
+#endif
         Screen.drawDisplay();
         vTaskDelay(DISPLAY_TASK_DELAY / portTICK_PERIOD_MS);
     }
@@ -179,8 +184,10 @@ void setup() {
     // Initialize Log
     Log.begin(LOG_LEVEL_VERBOSE, &Serial);
 
+#ifdef GPS_ENABLED
     // Initialize GPS
     initGPS();
+#endif
 
     // Initialize LoRaMesh
     initLoRaMesher();


### PR DESCRIPTION
New configuration option (GPS_ENABLED) which should be commented when the device does not have GPS.