### PR TITLE
Modify LoRaChat to use it as a library

### DIFF
--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -88,7 +88,7 @@ void initSensors() {
 WiFiServerService& wiFiService = WiFiServerService::getInstance();
 
 void initWiFi() {
-    wiFiService.initWiFi();
+    wiFiService.initWiFi("WiFi SSID", "WiFi Password");
 }
 
 #pragma endregion
@@ -111,7 +111,7 @@ void initLoRaMesher() {
 MqttService& mqttService = MqttService::getInstance();
 
 void initMQTT() {
-    mqttService.initMqtt(String(loraMeshService.getLocalAddress()));
+    mqttService.initMqtt(String(loraMeshService.getLocalAddress()), "192.168.1.26", 1883, "admin", "public");
 }
 
 #pragma endregion

--- a/examples/main_LC.cpp
+++ b/examples/main_LC.cpp
@@ -1,0 +1,21 @@
+#include <Arduino.h>
+#include "LoRaChat.cpp"
+#include "led/led.h"
+
+Led& led = Led::getInstance();
+LC lc;
+
+void setup() {
+    Serial.begin(115200);
+    Log.begin(LOG_LEVEL_VERBOSE, &Serial);
+
+    lc.init("WIFI_SSID", "WIFI_PASSWORD", "MQTT_SERVER", 1883, "MQTT_USERNAME", "MQTT_PASSWORD");
+    lc.registerApplication(&led);
+    lc.printCommands();
+
+    led.init();
+}
+
+void loop() {
+    delay(100);
+}

--- a/library.json
+++ b/library.json
@@ -1,0 +1,46 @@
+{
+  "name": "LoRaChat",
+  "version": "1.0.1",
+  "description": "",
+  "keywords": "",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/NilLlisterri/LoRaChat.git"
+  },
+  "authors":
+  [
+    {
+      "name": "John Smith",
+      "email": "me@john-smith.com",
+      "url": "https://www.john-smith/contact"
+    },
+    {
+      "name": "Andrew Smith",
+      "email": "me@andrew-smith.com",
+      "url": "https://www.andrew-smith/contact",
+      "maintainer": true
+    }
+  ],
+  "license": "MIT",
+  "homepage": "",
+  "dependencies": {
+    "Vector": "1.2.2",
+    "SPI": "*",
+    "WiFi": "2.0.0",
+    "Wire": "*",
+    "Preferences": "*",
+    "mikalhart/TinyGPSPlus": "1.0.3",
+    "lewisxhe/AXP202X_Library": "1.1.3",
+    "plerup/espsoftwareserial": "8.1.0",
+    "external-repo": "https://github.com/LoRaMesher/LoRaMesher#main",
+    "adafruit/Adafruit SSD1306": "^2.5.6",
+    "adafruit/Adafruit GFX Library": "^1.11.3",
+    "paulstoffregen/OneWire": "2.3.7",
+    "adafruit/Adafruit BusIO": "^1.11.1",
+    "bblanchon/ArduinoJson": "6.21.3",
+    "BluetoothSerial": "*"
+  },
+  "frameworks": "*",
+  "platforms": "*"
+}

--- a/library.json
+++ b/library.json
@@ -8,20 +8,22 @@
     "type": "git",
     "url": "https://github.com/NilLlisterri/LoRaChat.git"
   },
-  "authors":
-  [
+  "authors": [
     {
-      "name": "John Smith",
-      "email": "me@john-smith.com",
-      "url": "https://www.john-smith/contact"
+      "name": "Joan Miquel Solé",
+      "url": "https://www.github.com/Jaimi5",
+      "maintainer": true
     },
     {
-      "name": "Andrew Smith",
-      "email": "me@andrew-smith.com",
-      "url": "https://www.andrew-smith/contact",
-      "maintainer": true
+      "name": "Roger Pueyo"
+    },
+    {
+      "name": "Sergi Miralles"
+    },
+    {
+      "name": "Nil Llisterri Giménez"
     }
-  ],
+],
   "license": "MIT",
   "homepage": "",
   "dependencies": {
@@ -33,7 +35,7 @@
     "mikalhart/TinyGPSPlus": "1.0.3",
     "lewisxhe/AXP202X_Library": "1.1.3",
     "plerup/espsoftwareserial": "8.1.0",
-    "external-repo": "https://github.com/LoRaMesher/LoRaMesher#main",
+    "LoRaMesher": "https://github.com/LoRaMesher/LoRaMesher#main",
     "adafruit/Adafruit SSD1306": "^2.5.6",
     "adafruit/Adafruit GFX Library": "^1.11.3",
     "paulstoffregen/OneWire": "2.3.7",

--- a/library.json
+++ b/library.json
@@ -15,12 +15,6 @@
       "maintainer": true
     },
     {
-      "name": "Roger Pueyo"
-    },
-    {
-      "name": "Sergi Miralles"
-    },
-    {
       "name": "Nil Llisterri Giménez"
     }
 ],

--- a/src/LoRaChat.cpp
+++ b/src/LoRaChat.cpp
@@ -1,0 +1,75 @@
+#include "config.h"
+
+#include <Arduino.h>
+#include "ArduinoLog.h"
+#include "display.h"
+
+#include "helpers/helper.h"
+
+#include "message/messageManager.h"
+#include "loramesh/loraMeshService.h"
+#include "mqtt/mqttService.h"
+#include "wifi/wifiServerService.h"
+
+#include "commands/commandService.h"
+
+class LC {
+
+    private:
+        LoRaMeshService& loraMeshService = LoRaMeshService::getInstance();
+        WiFiServerService& wiFiService = WiFiServerService::getInstance();
+        MqttService& mqttService = MqttService::getInstance();
+        MessageManager& manager = MessageManager::getInstance();
+
+        void initManager() {
+            manager.init();
+            manager.addMessageService(&loraMeshService);
+            manager.addMessageService(&wiFiService);
+            manager.addMessageService(&mqttService);
+        }
+
+        void initWiFi(String wifi_ssid, String wifi_password) {
+            wiFiService.initWiFi(wifi_ssid, wifi_password);
+        }
+
+        void initLoRaMesher() {
+            loraMeshService.initLoraMesherService();
+        }
+
+        void initMqtt(String mqtt_server, uint mqtt_port, String mqtt_username, String mqtt_password) {
+            mqttService.initMqtt(String(loraMeshService.getLocalAddress()), mqtt_server, mqtt_port, mqtt_username, mqtt_password);
+        }
+
+        void initDisplay() {
+            Screen.initDisplay();
+            displayStatus();
+        }
+
+    public:
+            void init(String wifi_ssid, String wifi_password, String mqtt_server, uint mqtt_port, String mqtt_username, String mqtt_password) {
+            initManager();
+            initWiFi(wifi_ssid, wifi_password);
+            initLoRaMesher();
+            // Give some time for the WiFi to connect
+            vTaskDelay(10000 / portTICK_PERIOD_MS);
+            initMqtt(mqtt_server, mqtt_port, mqtt_username, mqtt_password);
+            initDisplay();
+        }
+
+        void registerApplication(MessageService *app) {
+            manager.addMessageService(app);
+        }
+
+        void displayStatus() {
+            char lineThree[25];
+            String lineTwo = String(loraMeshService.getLocalAddress()) + " | " + wiFiService.getIP();
+            sprintf(lineThree, "Free ram: %d", heap_caps_get_free_size(MALLOC_CAP_INTERNAL));
+            Screen.changeLineTwo(lineTwo);
+            Screen.changeLineThree(lineThree);
+            Screen.drawDisplay();
+        }
+
+        void printCommands() {
+            Serial.println(manager.getAvailableCommands());
+        }
+};

--- a/src/LoRaChat.cpp
+++ b/src/LoRaChat.cpp
@@ -72,4 +72,8 @@ class LC {
         void printCommands() {
             Serial.println(manager.getAvailableCommands());
         }
+
+        String getClients() {
+            return loraMeshService.getRoutingTable();
+        }
 };

--- a/src/config.h
+++ b/src/config.h
@@ -81,15 +81,12 @@
 #define MAX_CONNECTION_TRY 10
 
 // WiFi credentials
-#define WIFI_SSID "****"
-#define WIFI_PASSWORD "****"
+
+#define SIMULATOR_WIFI_SSID "****"
+#define SIMULATOR_WIFI_PASSWORD "****"
 
 // MQTT configuration
 #define MQTT_ENABLED
-#define MQTT_SERVER "192.168.1.26" 
-#define MQTT_PORT 1883
-#define MQTT_USERNAME "admin"
-#define MQTT_PASSWORD "public"
 #define MQTT_TOPIC_SUB "from-server/"
 #define MQTT_TOPIC_OUT "to-server/"
 #define MQTT_MAX_PACKET_SIZE 512 // 128, 256 or 512

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1,5 +1,7 @@
 #include "display.h"
 
+static const char* DISPLAY_TAG = "Display";
+
 Display::Display() {
 }
 
@@ -131,11 +133,11 @@ void Display::initDisplay() {
 
     // SSD1306_SWITCHCAPVCC = generate display voltage from 3.3V internally
     if (!display.begin(SSD1306_SWITCHCAPVCC, 0x3C, false, false)) {
-        Serial.println(F("SSD1306 allocation failed"));
+        ESP_LOGE(DISPLAY_TAG, "SSD1306 allocation failed");
         return;
     }
 
-    Serial.println(F("SSD1306 allocation Done"));
+    ESP_LOGI(DISPLAY_TAG, "SSD1306 allocation Done");
 
     display.clearDisplay();
 

--- a/src/message/dataMessage.h
+++ b/src/message/dataMessage.h
@@ -43,6 +43,10 @@ public:
 
     uint32_t messageSize; //Message Size of the payload no include header
 
+    virtual ~DataMessageGeneric() {
+        
+    }
+
     uint32_t getDataMessageSize() {
         return sizeof(DataMessageGeneric) + messageSize;
     }

--- a/src/mqtt/mqttService.cpp
+++ b/src/mqtt/mqttService.cpp
@@ -237,7 +237,11 @@ void MqttService::mqtt_service_subscribe(const char* topic) {
 void MqttService::mqtt_service_send(const char* topic, const char* data, int len) {
     int msg_id;
     msg_id = esp_mqtt_client_publish(client, topic, data, len, 2, 0);
-    ESP_LOGI(MQTT_TAG, "sent publish successful, msg_id %d", msg_id);
+    if (msg_id > 0) {
+        ESP_LOGI(MQTT_TAG, "sent publish successful, msg_id %d", msg_id);
+    } else {
+        ESP_LOGE(MQTT_TAG, "ESP MQTT client publish failed, error code: %d", msg_id);
+    }
 }
 
 void MqttService::process_message(const char* topic, const char* payload) {

--- a/src/mqtt/mqttService.cpp
+++ b/src/mqtt/mqttService.cpp
@@ -2,10 +2,14 @@
 
 static const char* MQTT_TAG = "MQTT";
 
-void MqttService::initMqtt(String lclName) {
+void MqttService::initMqtt(String lclName, String mqtt_server, uint mqtt_port, String mqtt_username, String mqtt_password) {
     ESP_LOGI(MQTT_TAG, "Initializing mqtt");
 
-    localName = lclName;
+    this->mqtt_server = mqtt_server;
+    this->mqtt_port = mqtt_port;
+    this->mqtt_username = mqtt_username;
+    this->mqtt_password = mqtt_password;
+    this->localName = lclName;
 
     mqtt_service_init(lclName.c_str());
 
@@ -203,7 +207,7 @@ static void mqtt_event_handler(void* handler_args, esp_event_base_t base, int32_
 }
 
 void MqttService::mqtt_app_start(const char* client_id) {
-    String uri = "mqtt://" + String(MQTT_SERVER) + ":" + String(MQTT_PORT);
+    String uri = "mqtt://" + String(this->mqtt_server) + ":" + String(this->mqtt_port);
 
     ESP_LOGI(MQTT_TAG, "MQTT URI: %s", uri.c_str());
 

--- a/src/mqtt/mqttService.h
+++ b/src/mqtt/mqttService.h
@@ -46,7 +46,7 @@ public:
         return instance;
     }
 
-    void initMqtt(String localName);
+    void initMqtt(String localName, String mqtt_server, uint mqtt_port, String mqtt_username, String mqtt_password);
 
     bool connect();
 
@@ -70,6 +70,11 @@ public:
     String localName = "";
 
 private:
+    String mqtt_server;
+    uint mqtt_port;
+    String mqtt_username;
+    String mqtt_password;
+
     MqttService(): MessageService(appPort::MQTTApp, String("MQTT")) {
         commandService = mqttCommandService;
     };

--- a/src/simulator/sim.cpp
+++ b/src/simulator/sim.cpp
@@ -121,8 +121,8 @@ void Sim::simLoop(void* pvParameters) {
 
         ESP_LOGV(SIM_TAG, "Simulator connecting to WiFi");
 
-        WiFiServerService::getInstance().addSSID(WIFI_SSID);
-        WiFiServerService::getInstance().addPassword(WIFI_PASSWORD);
+        WiFiServerService::getInstance().addSSID(SIMULATOR_WIFI_SSID);
+        WiFiServerService::getInstance().addPassword(SIMULATOR_WIFI_PASSWORD);
 
         WiFiServerService::getInstance().connectWiFi();
 
@@ -264,8 +264,8 @@ SimMessage* Sim::createSimMessage(SimCommand command) {
 }
 
 void Sim::sendStartSimMessage() {
-    WiFiServerService::getInstance().addSSID(WIFI_SSID);
-    WiFiServerService::getInstance().addPassword(WIFI_PASSWORD);
+    WiFiServerService::getInstance().addSSID(SIMULATOR_WIFI_SSID);
+    WiFiServerService::getInstance().addPassword(SIMULATOR_WIFI_PASSWORD);
 
     WiFiServerService::getInstance().connectWiFi();
 

--- a/src/wifi/wifiServerService.cpp
+++ b/src/wifi/wifiServerService.cpp
@@ -13,7 +13,10 @@ static const char* TAG = "WiFi";
 
 static int s_retry_num = 0;
 
-void WiFiServerService::initWiFi() {
+void WiFiServerService::initWiFi(String wifi_ssid, String wifi_password) {
+    this->ssid = wifi_ssid;
+    this->password = wifi_password;
+
     initialized = true;
 
     wifi_init_sta();
@@ -283,8 +286,8 @@ String WiFiServerService::getPassword() {
 bool WiFiServerService::restartWiFiData() {
     ConfigService& configService = ConfigService::getInstance();
 
-    this->ssid = WIFI_SSID;
-    this->password = WIFI_PASSWORD;
+    // this->ssid = WIFI_SSID;
+    // this->password = WIFI_PASSWORD;
 
     // this->ssid = configService.getConfig("WiFiSSid", DEFAULT_WIFI_SSID);
     // this->password = configService.getConfig("WiFiPsw", DEFAULT_WIFI_PASSWORD);

--- a/src/wifi/wifiServerService.h
+++ b/src/wifi/wifiServerService.h
@@ -41,7 +41,7 @@ public:
         return instance;
     }
 
-    void initWiFi();
+    void initWiFi(String wifi_ssid, String wifi_password);
 
     bool connectWiFi();
 


### PR DESCRIPTION
I've made a few changes to transform the application into a library:
- Moved the Wi-Fi credentials and MQTT connection details out of `config.h` so plaform.io does not override the user defined credentials automatically importing the file.
- Created the LC (**L**oRa**C**hat) class to make the library user-friendly.
- Moved the demo code to the examples' folder. This way, platform.io won't automatically include the files.
- Created the `library.json` file to list the library dependencies and have them installed automatically when using the library.

TODO: Find an alternative to declare the application ports when registering the application.